### PR TITLE
Assert that {chromote} is installed and find_chrome() isn't an exported function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     xaringan,
     zip
 Suggests:
-    chromote,
+    chromote (>= 0.0.0.9003),
     officer,
     pdftools,
     xaringanExtra,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R:
              comment = c(ORCID = "0000-0002-2657-9191")),
       person(given = "Garrick",
              family = "Aden-Buie",
-             role = "ctb",
+             role = "aut",
              email = "garrick@adenbuie.com",
              comment = c(ORCID = "0000-0002-7111-0077")),
       person(given = "Bryan",

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,18 +17,27 @@ test_path_ext <- function(path, expected_ext) {
 }
 
 assert_chrome_installed <- function() {
+    assert_chromote()
+
     chromePath <- NULL
     error <- paste0(
         "This function requires a local installation of the Chrome ",
         "browser. You can also use other browsers based on Chromium, ",
         "such as Chromium itself, Edge, Vivaldi, Brave, or Opera.")
     tryCatch({
-      chromePath <- chromote::find_chrome()
+      find_chrome <- utils::getFromNamespace("find_chrome", "chromote")
+      chromePath <- find_chrome()
       },
       error = function(e) { message(error) }
     )
     if (is.null(chromePath)) {
         stop(error)
+    }
+}
+
+assert_chromote <- function() {
+    if (!requireNamespace("chromote", quietly = TRUE)) {
+        stop("`chromote` is required: remotes::install_github('rstudio/chromote')")
     }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -119,7 +119,8 @@ append_to_file_path <- function(path, s) {
 print_build_status <- function(input, output_file) {
     cli::cli_process_start(
         "Building {.file {fs::path_file(output_file)}} from {.path {fs::path_file(input)}}",
-        on_exit = "done"
+        on_exit = "done",
+        .envir = parent.frame(n = 2)
     )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,8 +25,7 @@ assert_chrome_installed <- function() {
         "browser. You can also use other browsers based on Chromium, ",
         "such as Chromium itself, Edge, Vivaldi, Brave, or Opera.")
     tryCatch({
-      find_chrome <- utils::getFromNamespace("find_chrome", "chromote")
-      chromePath <- find_chrome()
+      chromePath <- chromote::find_chrome()
       },
       error = function(e) { message(error) }
     )
@@ -38,6 +37,9 @@ assert_chrome_installed <- function() {
 assert_chromote <- function() {
     if (!requireNamespace("chromote", quietly = TRUE)) {
         stop("`chromote` is required: remotes::install_github('rstudio/chromote')")
+    }
+    if (packageVersion("chromote") < package_version("0.0.0.9003")) {
+        warning("Please upgrade `chromote` to version 0.0.0.9003 or later.")
     }
 }
 


### PR DESCRIPTION
Calling `chromote::find_chrome()` was throwing an error because `find_chrome()` isn't exported by chromote. This PR works around that (and R CMD check errors) by using `utils::getFromNamespace()`.

Also, somewhat unrelated, I should have used the role `aut` for my previous PR since my contribution was more significant than a small change. Happy to discuss that change more if you want.