### PR TITLE
Change build_pptx

### DIFF
--- a/R/pptx.R
+++ b/R/pptx.R
@@ -8,7 +8,7 @@
 #' full url ending in ".html".
 #' @param output_file Name of the output pptx file.
 #' @param density Resolution of the resulting pngs in each slide file.
-#' Defaults to `"100x100"`.
+#' Defaults to `300`.
 #' @param complex_slides For "complex" slides (e.g. slides with panelsets or
 #' other html widgets or advanced features), set `complex_slides = TRUE`.
 #' Defaults to `FALSE`. This will use the {chromote} package to iterate through
@@ -32,7 +32,7 @@
 build_pptx <- function(
     input,
     output_file = NULL,
-    density = "100x100",
+    density = 300,
     complex_slides = FALSE,
     partial_slides = FALSE,
     delay = 1

--- a/R/utils.R
+++ b/R/utils.R
@@ -127,7 +127,7 @@ print_build_status <- function(input, output_file) {
 }
 
 pdf_to_pngs <- function(input, density) {
-    pdf <- magick::image_read(input, density = density)
+    pdf <- magick::image_read_pdf(input, density = density)
     pngs <- magick::image_convert(pdf, 'png')
     return(pngs)
 }


### PR DESCRIPTION
Hi @jhelvy ! This is what I did so the function could run in my machine.

I cloned the package, and first I tried to identify in which line I start getting an error (inside the function in the file `pptx.R`)


In this line I got an error:
https://github.com/jhelvy/xaringanBuilder/blob/df91080e813ff7b73c966f752a0faa049e9dc149/R/pptx.R#L60

 The step that is no working is when the PDF is converted to PNG.


But I think the problem is before, because the line before generates a tibble with 0 rows: 
```
> pdf_to_pngs(input, density)
# A tibble: 0 x 7
# … with 7 variables: format <chr>,
#   width <int>, height <int>,
#   colorspace <chr>, matte <lgl>,
#   filesize <int>, density <chr>
```

I tried to execute the function `pdf_to_pngs()` and the first line  also returned a empty tibble. The input that used is the pdf created inside the pptx.R function.  

I tested this function `pdf_to_pngs()` and changed a `magick::image_read()` to `magick::image_read_pdf()`. But in order for this to work I had to change the argument density, because this function receives a numeric. That fixed the problem. 

With the changes in this PR, now is working here. I tested only this function and now is working but I believe is needed more tests to see if this change in `pdf_to_pngs()` can create a bug in other functions that uses it. 

#19 