### PR TITLE
fix: Don't convert .Rmd to .rmd

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -54,7 +54,7 @@ build_paths <- function(input, output_file = NULL) {
       input_html <- fs::path_ext_set(input_root, "html")
       input_url  <- paste0("file://", input_html)
     }
-    input_rmd <- fs::path_ext_set(input_root, "rmd")
+    input_rmd <- input_root
     input_pdf <- fs::path_ext_set(input_root, "pdf")
 
     # Build output_file paths


### PR DESCRIPTION
Hi John,

Firstly, thanks for this package. It's a complete revelation. I've been building alternative formats of my slides by hand. The fact that there's a package that can do all of this simply and easily is going to make things _do_ much easier.

I did run into a minor problem using the package though. I generally use the `.Rmd` file extension on my R Markdown files. I think that there's probably a split between `.rmd` and `.Rmd` in the community.

However, I found that `{xaringanBuilder}` was insisting on `.rmd`.

![image](https://user-images.githubusercontent.com/6134409/120913189-6a40f200-c695-11eb-837f-fc2d5a16eadb.png)

When I tried to process my `.Rmd` file it gave an error saying that the `.rmd` (lowercase) didn't exist. The weird thing was that when I changed the file extension to lowercase but ran the same command (with the `.Rmd` extension) it now worked. This felt a little inconsistent! :)

I've made a minor change: just dropping the like in which you explicitly set the extension of the input to `.rmd`. I think that this still works fine though since you have a check which asserts that the input file has the extension `.rmd` (the check is case insensitive since you convert to lowercase first).

I hope that you'll accept this minor contribution to your cool package.

Best regards,
Andrew.