### PR TITLE
Catch failed/done status with cli

### DIFF
--- a/R/gif.R
+++ b/R/gif.R
@@ -56,7 +56,7 @@ build_gif <- function(
     # Build gif from pdf
     input <- paths$input$pdf
     output_file <- paths$output$gif
-    proc <- print_build_status(input, output_file)
+    proc <- cli_build_start(input, output_file)
     pngs <- pdf_to_pngs(input, density)
 
     # Keep only selected slides by number

--- a/R/gif.R
+++ b/R/gif.R
@@ -56,7 +56,7 @@ build_gif <- function(
     # Build gif from pdf
     input <- paths$input$pdf
     output_file <- paths$output$gif
-    print_build_status(input, output_file)
+    proc <- print_build_status(input, output_file)
     pngs <- pdf_to_pngs(input, density)
 
     # Keep only selected slides by number
@@ -67,5 +67,8 @@ build_gif <- function(
     # Build the gif
     pngs_joined <- magick::image_join(pngs)
     pngs_animated <- magick::image_animate(pngs_joined, fps = fps)
-    magick::image_write(pngs_animated, output_file)
+    res <- magick::image_write(pngs_animated, output_file)
+
+    cli::cli_process_done(proc)
+    res
 }

--- a/R/html.R
+++ b/R/html.R
@@ -22,11 +22,17 @@ build_html <- function(input, output_file = NULL) {
     output_file <- paths$output$html
 
     # Build html from rmd
-    print_build_status(input, output_file)
-    rmarkdown::render(
-        input = input,
-        output_file = output_file,
-        output_format = 'xaringan::moon_reader',
-        quiet = TRUE
+    proc <- print_build_status(input, output_file, on_exit = "done")
+    tryCatch(
+        rmarkdown::render(
+            input = input,
+            output_file = output_file,
+            output_format = 'xaringan::moon_reader',
+            quiet = TRUE
+        ),
+        error = function(err) {
+            cli::cli_process_failed(proc)
+            stop(err)
+        }
     )
 }

--- a/R/html.R
+++ b/R/html.R
@@ -22,7 +22,7 @@ build_html <- function(input, output_file = NULL) {
     output_file <- paths$output$html
 
     # Build html from rmd
-    proc <- print_build_status(input, output_file, on_exit = "done")
+    proc <- cli_build_start(input, output_file, on_exit = "done")
     tryCatch(
         rmarkdown::render(
             input = input,
@@ -30,9 +30,6 @@ build_html <- function(input, output_file = NULL) {
             output_format = 'xaringan::moon_reader',
             quiet = TRUE
         ),
-        error = function(err) {
-            cli::cli_process_failed(proc)
-            stop(err)
-        }
+        error = cli_build_failed(proc)
     )
 }

--- a/R/mp4.R
+++ b/R/mp4.R
@@ -56,7 +56,7 @@ build_mp4 <- function(
     # Build mp4 from pdf
     input <- paths$input$pdf
     output_file <- paths$output$mp4
-    print_build_status(input, output_file)
+    proc <- print_build_status(input, output_file)
     pngs <- pdf_to_pngs(input, density)
 
     # Keep only selected slides by number
@@ -73,13 +73,15 @@ build_mp4 <- function(
             pngs[i], fs::path(temp_folder, png_name))
         png_paths <- c(png_paths, png_path)
     }
-    av::av_encode_video(
+
+    res <- av::av_encode_video(
         input = png_paths,
         output = output_file,
         framerate = fps,
+        # vfilter argument added to avoid divisible by 2 error, see:
+        # https://github.com/ropensci/av/issues/2
         vfilter = "scale=trunc(iw/2)*2:trunc(ih/2)*2"
     )
-    # vfilter argument added to avoid divisible by 2 error, see:
-    # https://github.com/ropensci/av/issues/2
-
+    cli::cli_process_done(proc)
+    res
 }

--- a/R/mp4.R
+++ b/R/mp4.R
@@ -56,7 +56,7 @@ build_mp4 <- function(
     # Build mp4 from pdf
     input <- paths$input$pdf
     output_file <- paths$output$mp4
-    proc <- print_build_status(input, output_file)
+    proc <- cli_build_start(input, output_file)
     pngs <- pdf_to_pngs(input, density)
 
     # Keep only selected slides by number

--- a/R/pdf.R
+++ b/R/pdf.R
@@ -80,15 +80,14 @@ build_pdf <- function(
 }
 
 build_pdf_simple <- function(input, output_file = NULL) {
-    proc <- print_build_status(input, output_file, on_exit = "done")
+    proc <- cli_build_start(input, output_file, on_exit = "done")
     tryCatch({
       pagedown::chrome_print(
         input  = input,
         output = output_file)
-    }, error = function(err) {
-      cli::cli_process_failed(proc)
-      stop(err)
-    })
+    },
+      error = cli_build_failed(proc)
+    )
 }
 
 # build_pdf_complex() was previously xaringan_to_pdf(), added by gadenbuie
@@ -167,7 +166,7 @@ build_pdf_complex <- function(input, output_file, partial_slides, delay) {
     "document.head.appendChild(style)"
   ))
 
-  proc <- print_build_status(input, output_file)
+  proc <- cli_build_start(input, output_file)
 
   pb <- progress::progress_bar$new(
     format = "Slide :slide (:part) [:bar] Eta: :eta",

--- a/R/pdf.R
+++ b/R/pdf.R
@@ -80,10 +80,15 @@ build_pdf <- function(
 }
 
 build_pdf_simple <- function(input, output_file = NULL) {
-    print_build_status(input, output_file)
-    pagedown::chrome_print(
+    proc <- print_build_status(input, output_file, on_exit = "done")
+    tryCatch({
+      pagedown::chrome_print(
         input  = input,
         output = output_file)
+    }, error = function(err) {
+      cli::cli_process_failed(proc)
+      stop(err)
+    })
 }
 
 # build_pdf_complex() was previously xaringan_to_pdf(), added by gadenbuie
@@ -162,7 +167,7 @@ build_pdf_complex <- function(input, output_file, partial_slides, delay) {
     "document.head.appendChild(style)"
   ))
 
-  print_build_status(input, output_file)
+  proc <- print_build_status(input, output_file)
 
   pb <- progress::progress_bar$new(
     format = "Slide :slide (:part) [:bar] Eta: :eta",
@@ -224,5 +229,6 @@ build_pdf_complex <- function(input, output_file, partial_slides, delay) {
   pdftools::pdf_combine(pdf_files, output = output_file)
   fs::file_delete(pdf_files)
 
+  cli::cli_process_done(proc)
   invisible(output_file)
 }

--- a/R/png.R
+++ b/R/png.R
@@ -68,7 +68,7 @@ build_png <- function(
     if ((length(slides) > 1) | (slides == "all")) {
       output_file <- paths$output$zip
     }
-    proc <- print_build_status(input, output_file, on_exit = "done")
+    proc <- cli_build_start(input, output_file, on_exit = "done")
     pngs <- pdf_to_pngs(input, density)
     tryCatch({
       if (is.null(slides)) {
@@ -78,10 +78,9 @@ build_png <- function(
       } else {
         magick::image_write(pngs[slides], output_file)
       }
-    }, error = function(err) {
-      cli::cli_process_failed(proc)
-      stop(err)
-    })
+    },
+      error = cli_build_failed(proc)
+    )
 }
 
 zip_pngs <- function(pngs, slides, output_file) {
@@ -135,14 +134,11 @@ build_thumbnail <- function(input, output_file = NULL) {
     # Build png from html
     input <- paths$input$html
     output_file <- paths$output$thumbnail
-    proc <- print_build_status(input, output_file, on_exit = "done")
+    proc <- cli_build_start(input, output_file, on_exit = "done")
     tryCatch({
       pagedown::chrome_print(
         input  = input,
         output = output_file,
         format = "png")
-    }, error = function(err) {
-      cli::cli_process_failed(proc)
-      stop(err)
-    })
+    }, error = cli_build_failed(proc))
 }

--- a/R/pptx.R
+++ b/R/pptx.R
@@ -58,7 +58,7 @@ build_pptx <- function(
     # Build pptx from pdf
     input <- paths$input$pdf
     output_file <- paths$output$pptx
-    proc <- print_build_status(input, output_file)
+    proc <- cli_build_start(input, output_file)
     pngs <- pdf_to_pngs(input, density)
 
     # Keep only selected slides by number

--- a/R/pptx.R
+++ b/R/pptx.R
@@ -58,7 +58,7 @@ build_pptx <- function(
     # Build pptx from pdf
     input <- paths$input$pdf
     output_file <- paths$output$pptx
-    print_build_status(input, output_file)
+    proc <- print_build_status(input, output_file)
     pngs <- pdf_to_pngs(input, density)
 
     # Keep only selected slides by number
@@ -83,6 +83,7 @@ build_pptx <- function(
         )
     }
 
+    cli::cli_process_done(proc)
     print(doc, output_file)
 }
 

--- a/R/social.R
+++ b/R/social.R
@@ -38,7 +38,7 @@ build_social <- function(input, output_file = NULL) {
     output_file <- paths$output$social
 
     # Build png from rmd
-    proc <- print_build_status(input, output_file, on_exit = "done")
+    proc <- cli_build_start(input, output_file, on_exit = "done")
     tryCatch({
         webshot2::rmdshot(
             doc = input,
@@ -52,9 +52,6 @@ build_social <- function(input, output_file = NULL) {
                 )
             )
         )},
-        error = function(err) {
-            cli::cli_process_failed(proc)
-            stop(err)
-        }
+        error = cli_build_failed(proc)
     )
 }

--- a/R/social.R
+++ b/R/social.R
@@ -38,17 +38,23 @@ build_social <- function(input, output_file = NULL) {
     output_file <- paths$output$social
 
     # Build png from rmd
-    print_build_status(input, output_file)
-    webshot2::rmdshot(
-        doc = input,
-        file = output_file,
-        vheight = 600,
-        vwidth = 600 * 191 / 100,
-        rmd_args = list(
-            output_options = list(
-                nature = list(ratio = "191:100"),
-                self_contained = TRUE
+    proc <- print_build_status(input, output_file, on_exit = "done")
+    tryCatch({
+        webshot2::rmdshot(
+            doc = input,
+            file = output_file,
+            vheight = 600,
+            vwidth = 600 * 191 / 100,
+            rmd_args = list(
+                output_options = list(
+                    nature = list(ratio = "191:100"),
+                    self_contained = TRUE
+                )
             )
-        )
+        )},
+        error = function(err) {
+            cli::cli_process_failed(proc)
+            stop(err)
+        }
     )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -118,7 +118,7 @@ append_to_file_path <- function(path, s) {
     )
 }
 
-print_build_status <- function(input, output_file, on_exit = "failed") {
+cli_build_start <- function(input, output_file, on_exit = "failed") {
     input <- fs::path_file(input)
     output <- fs::path_file(output_file)
     cli::cli_process_start(
@@ -126,6 +126,13 @@ print_build_status <- function(input, output_file, on_exit = "failed") {
         on_exit = on_exit,
         .envir = parent.frame()
     )
+}
+
+cli_build_failed <- function(id) {
+  function(err) {
+    cli::cli_process_failed(id)
+    stop(err)
+  }
 }
 
 pdf_to_pngs <- function(input, density) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -118,13 +118,13 @@ append_to_file_path <- function(path, s) {
     )
 }
 
-print_build_status <- function(input, output_file) {
+print_build_status <- function(input, output_file, on_exit = "failed") {
     input <- fs::path_file(input)
     output <- fs::path_file(output_file)
     cli::cli_process_start(
         paste0("Building ", output, " from ", input),
-        on_exit = "done",
-        .envir = parent.frame(n = 2)
+        on_exit = on_exit,
+        .envir = parent.frame()
     )
 }
 


### PR DESCRIPTION
This PR refactors the process status printing with cli. The first change is to use `parent.frame()` rather than `parent.frame(n = 2)` so that done or failed message is printed when exiting the function where `print_build_status()` (since renamed) is called.

`cli_proccess_start()` by default will issue a _failed_ or _done_ message on exit, but it doesn't handle both. Only one or the other is handled automatically, otherwise we need to explicitly call the other status updating function. I've added `on_exit` as a function argument so we can better choose which one makes sense and then handle the other.

Because the setup has changed a bit, I renamed `print_build_status()` to `cli_build_start()`. In almost all cases, we need to store the return value of this function to later tell `cli::cli_process_done()` or `cli::cli_process_failed()` which state to update (leaving the other to be handled automatically).

Here are the two new patterns. The first is to manually indicate the process is done just before returning the final value, assuming that any other type of exit is a failure.

```
proc <- cli_build_start(input, output_file)

# do lots of things, some of which might not work out

cli::cli_process_done(proc)

return(final_value)
```

The other pattern is to wrap build function in a `tryCatch()`, catching errors and manually calling `cli_process_failed()`.

```
proc <- cli_build_start(input, output_file)
tryCatch({
  rmarkdown::render(...)
}, error = function(err) {
  cli::cli_process_failed(proc)
  stop(err)
})
```

but that's a little verbose so I added a small helper function to create the error handler


```
proc <- cli_build_start(input, output_file)
tryCatch({
  rmarkdown::render(...)
}, error = cli_build_failed(proc))
```

The end result is that the cli messages now include "done" and "failed" statuses...

```r
build_png("xaringanthemer/default.Rmd")
✓ Building default.html from default.Rmd ... done
x Building default.pdf from default.html ... failed
Error in force(expr) : 
  Failed to generate output. Reason: Failed to open http://127.0.0.1:7303/Users/garrick/Repos/xaringanBuilder/_dev/xaringanthemer/default_files/figure-html/plot-example-1.png (HTTP status code: 404)
```