### PR TITLE
Use cli fancy formatting again for build messages

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -133,7 +133,7 @@ cli_build_start <- function(input, output_file, on_exit = "failed") {
     # prepare the message right now in this environment, because we'll attach
     # the cli_process to the parent frame, where input and output don't exist
     msg <- cli::format_inline(
-        "Building {.field {output}} from {.file {input}}",
+        "Building {.file {input}} into {.field {output}}",
         .envir = environment()
     )
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -121,11 +121,15 @@ append_to_file_path <- function(path, s) {
 cli_build_start <- function(input, output_file, on_exit = "failed") {
     input <- fs::path_file(input)
     output <- fs::path_file(output_file)
-    cli::cli_process_start(
-        paste0("Building ", output, " from ", input),
-        on_exit = on_exit,
-        .envir = parent.frame()
+
+    # prepare the message right now in this environment, because we'll attach
+    # the cli_process to the parent frame, where input and output don't exist
+    msg <- cli::format_inline(
+        "Building {.field {output}} from {.file {input}}",
+        .envir = environment()
     )
+
+    cli::cli_process_start(msg, on_exit = on_exit, .envir = parent.frame())
 }
 
 cli_build_failed <- function(id) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -119,8 +119,16 @@ append_to_file_path <- function(path, s) {
 }
 
 cli_build_start <- function(input, output_file, on_exit = "failed") {
-    input <- fs::path_file(input)
-    output <- fs::path_file(output_file)
+    common_path <- fs::path_common(fs::path_abs(c(input, output_file)))
+    wd <- fs::path_wd()
+
+    if (identical(common_path, wd) && wd == fs::path_dir(input)) {
+        input <- fs::path_file(input)
+        output <- fs::path_file(output_file)
+    } else {
+        input <- fs::path_rel(input, start = wd)
+        output <- fs::path_rel(output_file, start = wd)
+    }
 
     # prepare the message right now in this environment, because we'll attach
     # the cli_process to the parent frame, where input and output don't exist

--- a/R/utils.R
+++ b/R/utils.R
@@ -119,16 +119,8 @@ append_to_file_path <- function(path, s) {
 }
 
 cli_build_start <- function(input, output_file, on_exit = "failed") {
-    common_path <- fs::path_common(fs::path_abs(c(input, output_file)))
-    wd <- fs::path_wd()
-
-    if (identical(common_path, wd) && wd == fs::path_dir(input)) {
-        input <- fs::path_file(input)
-        output <- fs::path_file(output_file)
-    } else {
-        input <- fs::path_rel(input, start = wd)
-        output <- fs::path_rel(output_file, start = wd)
-    }
+    input <- fs::path_rel(input, start = fs::path_wd())
+    output <- fs::path_rel(output_file, start = fs::path_wd())
 
     # prepare the message right now in this environment, because we'll attach
     # the cli_process to the parent frame, where input and output don't exist


### PR DESCRIPTION
This resolves the issue previously seen in #19 where `output_file` wasn't found and that was caused by a confused `cli_process_start()` when called within a function but attached to a different environment (where `output_file` didn't exist).

This fixes that particular issue by building the message first using `cli::format_inline()` before calling `cli_process_start()`.

While in there I also updated the printing method. I reversed the phrasing to _Building **input** into **output**_ since I think this reads in chains better (the output of one line becomes the input of the next).

I also updated the messages to provide a little more context about where the files are being written by printing the paths relative to the working directory.

![image](https://user-images.githubusercontent.com/5420529/125883173-9f7a8ba4-64ee-4a0a-8efe-1b18a1d10054.png)