### PR TITLE
fix(to_pptx): pptx slides ratio

### DIFF
--- a/R/pptx.R
+++ b/R/pptx.R
@@ -13,7 +13,7 @@
 #' @inheritParams to_png
 #' @inheritParams to_pdf
 #' @param ratio PowerPoint slides ratio. Possible values are
-#'   `"4:3"``, `"16:9"``, or `"guess"``. Default to "guess".
+#'   `"4:3"`, `"16:9"`. Default to `NULL`, meaning it will be guessed frm the slides.
 #'
 #' @return Slides are rendered as a pptx file.
 #'
@@ -29,7 +29,7 @@ to_pptx <- function(
     partial_slides = FALSE,
     delay = 1,
     keep_intermediates = FALSE,
-    ratio = "guess"
+    ratio = NULL
 ) {
     if (!requireNamespace("officer", quietly = TRUE)) {
         stop("`officer` is required: install.packages('officer')")
@@ -89,7 +89,7 @@ to_pptx <- function(
     print(doc, output_file)
 }
 
-get_pptx_template <- function(png, ratio = "guess") {
+get_pptx_template <- function(png, ratio = NULL) {
     dims <- magick::image_info(png)
     ar <- dims$width / dims$height
     pptx_ratio <- c(
@@ -100,7 +100,7 @@ get_pptx_template <- function(png, ratio = "guess") {
         "4:3" = "4-3.pptx",
         "16:9" = "16-9.pptx"
     )
-    if (ratio %in% "guess" || !ratio %in% c("4:3", "16:9")) {
+    if (is.null(ratio) || !ratio %in% c("4:3", "16:9")) {
         ratio <- names(which.min(abs(pptx_ratio - ar)))
     }
 

--- a/man/to_pptx.Rd
+++ b/man/to_pptx.Rd
@@ -12,7 +12,8 @@ to_pptx(
   complex_slides = FALSE,
   partial_slides = FALSE,
   delay = 1,
-  keep_intermediates = FALSE
+  keep_intermediates = FALSE,
+  ratio = "guess"
 )
 }
 \arguments{
@@ -45,6 +46,9 @@ Only used if \code{complex_slides = TRUE} or \code{partial_slides = TRUE}.}
 
 \item{keep_intermediates}{Should we keep the intermediate files used to
 render the final output? The default is \code{FALSE}.}
+
+\item{ratio}{PowerPoint slides ratio. Possible values are
+\verb{"4:3"``, }"16:9"\verb{, or `"guess"}. Default to "guess".}
 }
 \value{
 Slides are rendered as a pptx file.

--- a/man/to_pptx.Rd
+++ b/man/to_pptx.Rd
@@ -13,7 +13,7 @@ to_pptx(
   partial_slides = FALSE,
   delay = 1,
   keep_intermediates = FALSE,
-  ratio = "guess"
+  ratio = NULL
 )
 }
 \arguments{
@@ -48,7 +48,7 @@ Only used if \code{complex_slides = TRUE} or \code{partial_slides = TRUE}.}
 render the final output? The default is \code{FALSE}.}
 
 \item{ratio}{PowerPoint slides ratio. Possible values are
-\verb{"4:3"``, }"16:9"\verb{, or `"guess"}. Default to "guess".}
+\code{"4:3"}, \code{"16:9"}. Default to \code{NULL}, meaning it will be guessed frm the slides.}
 }
 \value{
 Slides are rendered as a pptx file.


### PR DESCRIPTION
This PR improves how the PPTX template based on slides ratio is "guessed".
It also adds a "ratio" parameter in `to_pptx()` to enforce the ratio template to use:  `"4:3"``, `"16:9"``, or `"guess"``. Default to "guess".