### PR TITLE
fix(to_html): `quarto_render()` doesn't allow absolute paths for `output` anymore

### DIFF
--- a/R/html.R
+++ b/R/html.R
@@ -62,9 +62,13 @@ to_html <- function(from, to = NULL, self_contained = FALSE, render_args = NULL)
         withr::local_dir(fs::path_dir(input))
 
         if (self_contained) {
-            render_args$output_file <- path_from(
+            # path_from() returns an absolute path
+            temp_output_file <- path_from(
                 fs::path_file(render_args$output_file), "html", temporary = TRUE
             )
+            # discard the path directory so that rmd/qmd is rendered into source dir
+            render_args$output_file <- fs::path_file(temp_output_file)
+            # and then move the output into the right place at the end
             withr::defer(
                 fs::file_move(render_args$output_file, output_file),
                 priority = "first"


### PR DESCRIPTION
Fixes #71 

`quarto render --output /an/absolute/path` throws an error that

```
ERROR: --output option cannot specify a relative or absolute path
```

We were previously giving `quarto_render()` an absolute path, but the path points to a location in the same directory as the source file. `quarto render` must have previously been more forgiving in this case, but now it detects the absolute path and throws.

This PR just makes the temp file path relative for the render step, which is fine for both `rmarkdown::render()` and `quarto::quarto_render()`.